### PR TITLE
[SRE1-359] Update base PHP version;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # FIRST STEP - BUILDING PHP EXTENSIONS        #
 # =========================================== #
 
-FROM php:7.1.21-fpm-alpine AS build-env
+FROM php:7.1.22-fpm-alpine AS build-env
 
 # PREPARE
 RUN docker-php-source extract
@@ -125,7 +125,7 @@ RUN docker-php-ext-enable \
 # SECOND STEP - BUILDING PHP CONTAINER ITSELF #
 # =========================================== #
 
-FROM php:7.1.21-fpm-alpine
+FROM php:7.1.22-fpm-alpine
 
 # CONFIGURE APK
 # https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Repository_pinning


### PR DESCRIPTION
# Version 7.1.22

* 13 Sep 2018
* http://php.net/ChangeLog-7.php#7.1.22

## Core:

* Fixed bug #76754 (parent private constant in extends class memory leak).
* Fixed bug #72443 (Generate enabled extension).

## Apache2:

* Fixed bug #76582 (Apache bucket brigade sometimes becomes invalid).

## Bz2:

* Fixed arginfo for bzcompress.

## gettext:

* Fixed bug #76517 (incorrect restoring of LDFLAGS).

## iconv:

* Fixed bug #68180 (iconv_mime_decode can return extra characters in a header).
* Fixed bug #63839 (iconv_mime_decode_headers function is skipping headers).
* Fixed bug #60494 (iconv_mime_decode does ignore special characters).
* Fixed bug #55146 (iconv_mime_decode_headers() skips some headers).

## intl:

* Fixed bug #74484 (MessageFormatter::formatMessage memory corruption with 11+ named placeholders).

## libxml:

* Fixed bug #76777 ("public id" parameter of libxml_set_external_entity_loader callback undefined).

## mbstring:

* Fixed bug #76704 (mb_detect_order return value varies based on argument type).

## Opcache:

* Fixed bug #76747 (Opcache treats path containing "test.pharma.tld" as a phar file).

## OpenSSL:
* Fixed bug #76705 (unusable ssl => peer_fingerprint in stream_context_create()).

## phpdbg:

* Fixed bug #76595 (phpdbg man page contains outdated information).

## SPL:

* Fixed bug #68825 (Exception in DirectoryIterator::getLinkTarget()).
* Fixed bug #68175 (RegexIterator pregFlags are NULL instead of 0).

## Standard:

* Fixed bug #76778 (array_reduce leaks memory if callback throws exception).

## zlib:

* Fixed bug #65988 (Zlib version check fails when an include/zlib/ style dir is passed to the --with-zlib configure option).
* Fixed bug #76709 (Minimal required zlib library is 1.2.0.4).