### PR TITLE
[SRE1-480] Use 7.2 as base;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # FIRST STEP - BUILDING PHP EXTENSIONS        #
 # =========================================== #
 
-FROM php:7.1.22-fpm-alpine AS build-env
+FROM php:7.2.11-fpm-alpine AS build-env
 
 # PREPARE
 RUN docker-php-source extract
@@ -47,7 +47,6 @@ RUN docker-php-ext-configure \
     gd --with-freetype-dir=/usr/lib --with-jpeg-dir=/usr/lib --with-png-dir=/usr/lib
 
 RUN docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) \
-    mcrypt \
     mysqli \
     bz2 \
     opcache \
@@ -75,6 +74,7 @@ RUN docker-php-ext-enable opcache
 RUN pecl channel-update pecl.php.net
 
 RUN pecl install \
+    mcrypt \
     amqp \
     apcu \
     geoip-beta \
@@ -125,7 +125,7 @@ RUN docker-php-ext-enable \
 # SECOND STEP - BUILDING PHP CONTAINER ITSELF #
 # =========================================== #
 
-FROM php:7.1.22-fpm-alpine
+FROM php:7.2.11-fpm-alpine
 
 # CONFIGURE APK
 # https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Repository_pinning

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,4 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: anchorfree/php-base:latest
+    image: anchorfree/php-base:master


### PR DESCRIPTION
# RELEASE NOTES

* http://php.net/manual/en/migration72.php

```
AF6428:docker-php-base ailyin$ docker-compose run php-fpm php-fpm -d extension_dir=/usr/local/etc/php/extensions -v
PHP 7.2.11 (fpm-fcgi) (built: Oct 15 2018 18:55:43)
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.2.11, Copyright (c) 1999-2018, by Zend Technologies
```